### PR TITLE
Mint-check-translations didn't find "polib.py"

### DIFF
--- a/usr/bin/mint-check-translations
+++ b/usr/bin/mint-check-translations
@@ -1,8 +1,9 @@
 #!/usr/bin/python2
 # coding=utf-8
 import argparse
-import polib
 import sys
+sys.path.insert(1, '/usr/lib/python3/dist-packages')
+import polib
 import os
 import subprocess
 import threading


### PR DESCRIPTION
The script collapsed when checking a corrected version of the German Installation Guide because "polib" wasn't found. After including a path in line 5 and putting "import sys" to line 4 the script worked.
OS: LM 19.3

I have neither experience with Python nor with Github. Sorry, if there may be any inconveniencies. 

Kind regards, erwn16